### PR TITLE
Fix modal deploy bug

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -45,8 +45,7 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
-          pip install modal
-          modal deploy backend.py
+          uv run --no-dev --with modal modal deploy backend.py
 
       # Step 6: Authenticate to Google Cloud
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
fix: use uv run for modal deployment to resolve ModuleNotFoundError: pydantic

Using `uv run` ensures that the project's dependencies (like Pydantic) are available
in the GitHub Actions runner when parsing `backend.py` for deployment.